### PR TITLE
Add @staticmethod on methods and properties

### DIFF
--- a/PyStubbler/StubBuilder.cs
+++ b/PyStubbler/StubBuilder.cs
@@ -233,6 +233,10 @@ namespace PyStubbler
                         else if (p.ParameterType.IsByRef)
                             refParamCount++;
                     }
+
+                    if (method.IsStatic)
+                        sb.AppendLine("    @staticmethod");
+
                     int parameterCount = parameters.Length - outParamCount;
 
                     if (method.IsSpecialName && (method.Name.StartsWith("get_") || method.Name.StartsWith("set_")))


### PR DESCRIPTION
We're not marking static methods with @staticmethod, which makes PyCharm interpret the first parameter as self

C# code to trigger the issue:

    public class StaticTests
    {
        public static void StaticMethod() { }
        public static void StaticOverloadedMethod() { }
        public static void StaticOverloadedMethod(int param) { }

    }

    public class PropertyTests
    {
        public static int StaticGetProperty { get; }
        public static int StaticGetSetProperty { get; set; }
        public int GetProperty { get; }
        public int GetSetProperty { get; set; }
    }

How the issue is seen in PyCharm:

![image](https://github.com/daddycocoaman/PyStubbler/assets/1709509/25515289-4387-4628-a584-e23839faf2bb)

With this change:
![image](https://github.com/daddycocoaman/PyStubbler/assets/1709509/3461ae38-8660-4850-a312-ffc5f2569eb2)


Judging by PyCharm's warning, @staticmethod needs to be added first, as both @overload and @property decorators expect to have direct access to the real method, but static method doesn't.
