### PR TITLE
Convert Single to float

### DIFF
--- a/PyStubbler/StubBuilder.cs
+++ b/PyStubbler/StubBuilder.cs
@@ -343,7 +343,7 @@ namespace PyStubbler
 
             if (rc.Equals("String"))
                 return "str";
-            if (rc.Equals("Double"))
+            if (rc.Equals("Single") || rc.Equals("Double"))
                 return "float";
             if (rc.Equals("Boolean"))
                 return "bool";


### PR DESCRIPTION
We convert all primitive C# types to python types, but we don't do it with float (Single).
Single is not a keyword, but we're also not importing it, so it's not properly recognized and it's being marked as an error by PyCharm.


C# code to trigger the issue:

    public class SingleVsFloatTests
    {
        public SingleVsFloatTests(float param) { }
        public void Method(float param) { }
        public float ReturnFloat() { return 0; }
    }

Before the change:
![image](https://github.com/daddycocoaman/PyStubbler/assets/1709509/1f52c315-aaa9-482e-b9bc-c767a1798244)

After the change:
![image](https://github.com/daddycocoaman/PyStubbler/assets/1709509/b62e1470-269b-4a58-a4f7-8931bdc83ae6)
