### PR TITLE
Add write permissions to dotnet.yml workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -48,3 +48,6 @@ jobs:
           files: "dist/PyStubbler*"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+permissions:
+  contents: write


### PR DESCRIPTION
This should fix "GitHub release failed with status: 403"
Recommended in: https://github.com/softprops/action-gh-release/issues/236